### PR TITLE
Fix forceOverwrite setting name

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -14,7 +14,7 @@ const compressImage = (file: Uri) => {
     const shouldOverwrite: boolean =
         vscode.workspace
             .getConfiguration('tinypng')
-            .get<boolean>('overwriteforceOverwrite') || false;
+            .get<boolean>('forceOverwrite') || false;
 
     // Note: Define the destination file path for the compressed image.
     let destinationFilePath = file.fsPath;


### PR DESCRIPTION
There is a typo preventing the `forceOverwrite` setting from working as intended.

The extension has a setting `forceOverwrite`, but setting it to `true` does not have an affect, because
the extension is expecting `overwriteforceOverwrite`.